### PR TITLE
Dont use flags for meta chars

### DIFF
--- a/regex/operators/assembler.go
+++ b/regex/operators/assembler.go
@@ -18,21 +18,8 @@ import (
 	"github.com/theseion/crs-toolchain/v2/regex/processors"
 )
 
-const (
-	preprocessorStartRegex = `^##!>\s*([a-z]+)(?:\s+([a-z]+))?`
-	preprocessorEndRegex   = `^##!<`
-	doubleQuotesRegex      = `([^\\])"`
-)
-
-var regexes = struct {
-	preprocessorStart regexp.Regexp
-	preprocessorEnd   regexp.Regexp
-	doubleQuotesRegex regexp.Regexp
-}{
-	preprocessorStart: *regexp.MustCompile(preprocessorStartRegex),
-	preprocessorEnd:   *regexp.MustCompile(preprocessorEndRegex),
-	doubleQuotesRegex: *regexp.MustCompile(doubleQuotesRegex),
-}
+var preprocessorStart = regexp.MustCompile(`^##!>\s*([a-z]+)(?:\s+([a-z]+))?`)
+var preprocessorEnd = regexp.MustCompile(`^##!<`)
 
 // Create the processor stack
 var processorStack ProcessorStack
@@ -40,14 +27,13 @@ var processor processors.IProcessor
 
 // NewAssembler creates a new Operator based on context.
 func NewAssembler(ctx *processors.Context) *Operator {
-	a := &Operator{
+	return &Operator{
 		name:    "assemble",
 		details: make(map[string]string),
 		lines:   []string{},
 		ctx:     ctx,
 		stats:   NewStats(),
 	}
-	return a
 }
 
 func (a *Operator) Run(input string) (string, error) {
@@ -73,11 +59,11 @@ func (a *Operator) Assemble(assembleParser *parser.Parser, input *bytes.Buffer) 
 		line := fileScanner.Text()
 		logger.Trace().Msgf("parsing line: %q", line)
 
-		if procline := regexes.preprocessorStart.FindStringSubmatch(line); len(procline) > 0 {
+		if procline := preprocessorStart.FindStringSubmatch(line); len(procline) > 0 {
 			if err := a.startPreprocessor(procline[1], procline[2:]); err != nil {
 				return "", err
 			}
-		} else if regexes.preprocessorEnd.MatchString(line) {
+		} else if preprocessorEnd.MatchString(line) {
 			lines, err := a.endPreprocessor()
 			if err != nil {
 				return "", err
@@ -146,6 +132,8 @@ func (a *Operator) complete(assembleParser *parser.Parser) string {
 		logger.Trace().Msgf("After use hex backslashes: %s\n", result)
 		result = a.includeVerticalTabInSpaceClass(result)
 		logger.Trace().Msgf("After including vertical tabs: %s\n", result)
+		result = a.dontUseFlagsForMetaCharacters(result)
+		logger.Trace().Msgf("After removing meta character flags: %s\n", result)
 	}
 
 	if len(flagsPrefix) > 0 && len(result) > 0 {
@@ -252,6 +240,15 @@ func (a *Operator) useHexEscapes(input string) string {
 		}
 	}
 	return sb.String()
+}
+
+// The Go regexp/syntax library will convert a dot (`.`) into `(?-s:.)`,
+// `^` to `(?m:^)`, `$` to (?m:$)`.
+// We want to retain the original dot.
+func (a *Operator) dontUseFlagsForMetaCharacters(input string) string {
+	result := strings.ReplaceAll(input, "(?-s:.)", ".")
+	result = strings.ReplaceAll(result, "(?m:^)", "^")
+	return strings.ReplaceAll(result, "(?m:$)", "$")
 }
 
 func (a *Operator) startPreprocessor(processorName string, args []string) error {

--- a/regex/operators/assembler_test.go
+++ b/regex/operators/assembler_test.go
@@ -726,6 +726,7 @@ cd
   ##!=< globalinput
   ##!<
 ##!=> globalinput
+##!<
 `
 	assembler := NewAssembler(s.ctx)
 
@@ -735,14 +736,16 @@ cd
 	s.Equal(`ab|cd`, output)
 
 }
+
 func (s *assemblerTestSuite) TestAssemble_ConcatenatingFailsWhenInputUnknown() {
 	contents := `##!> assemble
 ##!=> unknown
+##!<
 `
 	assembler := NewAssembler(s.ctx)
 
 	_, err := assembler.Run(contents)
-	s.Error(err)
+	s.EqualError(err, "no entry in the stash for name 'unknown'")
 
 }
 func (s *assemblerTestSuite) TestAssemble_StoringAlternationAndConcatenation() {

--- a/regex/operators/assembler_test.go
+++ b/regex/operators/assembler_test.go
@@ -26,6 +26,7 @@ type definitionsTestSuite assemblerTestSuite
 
 func TestRunAssemblerTestSuite(t *testing.T) {
 	suite.Run(t, new(fileFormatTestSuite))
+	suite.Run(t, new(assemblerTestSuite))
 	suite.Run(t, new(specialCommentsTestSuite))
 	suite.Run(t, new(specialCasesTestSuite))
 	suite.Run(t, new(preprocessorsTestSuite))
@@ -567,12 +568,13 @@ ab
 ##!<
 ##!> assemble
 ##!=> myinput
+##!<
 `
 	assembler := NewAssembler(s.ctx)
 
 	output, err := assembler.Run(contents)
 	s.NoError(err)
-	s.Equal(`ab`, output)
+	s.Equal("ab", output)
 
 }
 func (s *assemblerTestSuite) TestAssemble_Concatenating() {
@@ -650,6 +652,7 @@ ten
 	s.Equal(`(?:one|two)(?:three|four)five(?:s(?:ix|even)(?:eight|nine)|ten)`, output)
 
 }
+
 func (s *assemblerTestSuite) TestAssemble_ConcatenatingWithStoredInput() {
 	contents := `##!> assemble
 ##! slash patterns
@@ -666,6 +669,7 @@ func (s *assemblerTestSuite) TestAssemble_ConcatenatingWithStoredInput() {
 \.%01
 ##!=>
 ##!=> slashes
+##!<
 `
 	assembler := NewAssembler(s.ctx)
 
@@ -675,6 +679,7 @@ func (s *assemblerTestSuite) TestAssemble_ConcatenatingWithStoredInput() {
 	s.Equal(`(?:\x5c|%(?:2f|5c))\.(?:%0[0-1])?(?:\x5c|%(?:2f|5c))`, output)
 
 }
+
 func (s *assemblerTestSuite) TestAssemble_StoredInputIsGlobal() {
 	contents := `##!> assemble
 ab
@@ -684,6 +689,7 @@ cd
 
 ##!> assemble
 ##!=> globalinput1
+##!<
 `
 	assembler := NewAssembler(s.ctx)
 
@@ -693,7 +699,8 @@ cd
 	s.Equal(`ab|cd`, output)
 
 }
-func (s *assemblerTestSuite) TestAssemble_StoredInputIsntAvailableToInnerScope() {
+
+func (s *assemblerTestSuite) TestAssemble_StoredInputIsAvailableToInnerScope() {
 	contents := `##!> assemble
 ab
 cd
@@ -705,10 +712,12 @@ cd
 `
 	assembler := NewAssembler(s.ctx)
 
-	_, err := assembler.Run(contents)
-	s.Error(err)
+	output, err := assembler.Run(contents)
+	s.NoError(err)
 
+	s.Equal("ab|cd", output)
 }
+
 func (s *assemblerTestSuite) TestAssemble_StoredInputIsAvailableToOuterScope() {
 	contents := `##!> assemble
   ##!> assemble
@@ -833,4 +842,76 @@ func (s *assemblerTestSuite) TestAssemble_RemoveExtraGroups() {
 	s.NoError(err)
 
 	s.Equal(`a[b-c]d`, output)
+}
+
+// The Go regexp/syntax library will convert a dot (`.`) into `(?-s:.)`.
+// We want to retain the original dot.
+func (s *assemblerTestSuite) TestAssemble_DotRemainsDot() {
+	contents := "a.b"
+	assembler := NewAssembler(s.ctx)
+
+	output, err := assembler.Run(contents)
+
+	s.NoError(err)
+	s.Equal("a.b", output)
+}
+
+// The Go regexp/syntax library will convert a dot (`.`) into `(?s:.)`.
+// We want to retain the original dot.
+func (s *assemblerTestSuite) TestAssemble_DotRemainsDotWithSflag() {
+	contents := "##!+ s\na.b"
+	assembler := NewAssembler(s.ctx)
+
+	output, err := assembler.Run(contents)
+
+	s.NoError(err)
+	s.Equal("(?s)a.b", output)
+}
+
+// The Go regexp/syntax library will convert a caret (`^`) into `(?m:^)`.
+// We want to retain the original dot.
+func (s *assemblerTestSuite) TestAssemble_CaretRemainsCaret() {
+	contents := "^a|b"
+	assembler := NewAssembler(s.ctx)
+
+	output, err := assembler.Run(contents)
+
+	s.NoError(err)
+	s.Equal("^a|b", output)
+}
+
+// The Go regexp/syntax library will convert a caret (`^`) into `(?m:^)`.
+// We want to retain the original dot.
+func (s *assemblerTestSuite) TestAssemble_CaretRemainsCaretWithSflag() {
+	contents := "##!+ s\n^a|b"
+	assembler := NewAssembler(s.ctx)
+
+	output, err := assembler.Run(contents)
+
+	s.NoError(err)
+	s.Equal("(?s)^a|b", output)
+}
+
+// The Go regexp/syntax library will convert a dollar (`$`) into `(?m:$)`.
+// We want to retain the original dot.
+func (s *assemblerTestSuite) TestAssemble_DollarRemainsDollar() {
+	contents := "a|b$"
+	assembler := NewAssembler(s.ctx)
+
+	output, err := assembler.Run(contents)
+
+	s.NoError(err)
+	s.Equal("a|b$", output)
+}
+
+// The Go regexp/syntax library will convert a dollar (`$`) into `(?m:$)`.
+// We want to retain the original dot.
+func (s *assemblerTestSuite) TestAssemble_DollarRemainsDollarWithSflag() {
+	contents := "##!+ s\na|b$"
+	assembler := NewAssembler(s.ctx)
+
+	output, err := assembler.Run(contents)
+
+	s.NoError(err)
+	s.Equal("(?s)a|b$", output)
 }

--- a/regex/processors/assemble_test.go
+++ b/regex/processors/assemble_test.go
@@ -57,29 +57,35 @@ func (s *assembleTestSuite) TestNewAssemble() {
 
 func (s *assembleTestSuite) TestAssemble_MultipleLines() {
 	assemble := NewAssemble(s.ctx)
-	assemble.ProcessLine("homer")
-	assemble.ProcessLine("simpson")
+	err := assemble.ProcessLine("homer")
+	s.NoError(err)
+	err = assemble.ProcessLine("simpson")
+	s.NoError(err)
 	output, err := assemble.Complete()
 
 	s.NoError(err)
 	s.Len(output, 1)
-	s.Equal("(?:homer|simpson)", output[0])
+	s.Equal("(?:(?:homer|simpson))", output[0])
 }
 
 func (s *assembleTestSuite) TestAssemble_RegularExpressions() {
 	assemble := NewAssemble(s.ctx)
-	assemble.ProcessLine("home[r,]")
-	assemble.ProcessLine(".imps[a-c]{2}n")
+	err := assemble.ProcessLine("home[r,]")
+	s.NoError(err)
+	err = assemble.ProcessLine(".imps[a-c]{2}n")
+	s.NoError(err)
 	output, err := assemble.Complete()
 
 	s.NoError(err)
 	s.Len(output, 1)
-	s.Equal("(?:home[,r]|(?-s:.)imps[a-c]{2}n)", output[0])
+	s.Equal("(?:(?:home[,r]|(?-s:.)imps[a-c]{2}n))", output[0])
 }
 
 func (s *assembleTestSuite) TestAssemble_InvalidRegularExpressionFails() {
 	assemble := NewAssemble(s.ctx)
-	assemble.ProcessLine("home[r")
-	_, err := assemble.Complete()
+	err := assemble.ProcessLine("home[r")
+	s.NoError(err)
+
+	_, err = assemble.Complete()
 	s.Error(err)
 }

--- a/regex/processors/cmdline.go
+++ b/regex/processors/cmdline.go
@@ -99,7 +99,7 @@ func NewCmdLine(ctx *Context, cmdType CmdLineType) *CmdLine {
 	return a
 }
 
-// ProcessLine implements the line processor
+// ProcessLine applies the processors logic to a single line
 func (c *CmdLine) ProcessLine(line string) {
 	if len(line) != 0 {
 		processed := c.regexpStr(line)
@@ -109,7 +109,7 @@ func (c *CmdLine) ProcessLine(line string) {
 	}
 }
 
-// Complete is the class method
+// Complete finalizes the processor, producing its output
 func (c *CmdLine) Complete() ([]string, error) {
 	assembly, err := rassemble.Join(c.proc.lines)
 	if err != nil {
@@ -117,6 +117,13 @@ func (c *CmdLine) Complete() ([]string, error) {
 	}
 	logger.Trace().Msgf("cmdLine Complete result: %v", assembly)
 	return []string{assembly}, nil
+}
+
+// Consume applies the state of a nested processor
+func (c *CmdLine) Consume(lines []string) {
+	for _, line := range lines {
+		c.ProcessLine(line)
+	}
 }
 
 // regexpStr converts a single line to regexp format, and insert anti-cmdline
@@ -157,10 +164,4 @@ func (c *CmdLine) regexpChar(char byte) string {
 	}
 	logger.Trace().Msgf("regexpChar out: %s", chars)
 	return strings.Replace(chars, " ", "\\s+", -1)
-}
-
-func (c *CmdLine) Consume(lines []string) {
-	for _, line := range lines {
-		c.ProcessLine(line)
-	}
 }

--- a/regex/processors/cmdline.go
+++ b/regex/processors/cmdline.go
@@ -100,13 +100,14 @@ func NewCmdLine(ctx *Context, cmdType CmdLineType) *CmdLine {
 }
 
 // ProcessLine applies the processors logic to a single line
-func (c *CmdLine) ProcessLine(line string) {
+func (c *CmdLine) ProcessLine(line string) error {
 	if len(line) != 0 {
 		processed := c.regexpStr(line)
 		c.proc.lines = append(c.proc.lines, processed)
 		logger.Trace().Msgf("cmdline in: %s", line)
 		logger.Trace().Msgf("cmdline out: %s", processed)
 	}
+	return nil
 }
 
 // Complete finalizes the processor, producing its output
@@ -120,10 +121,13 @@ func (c *CmdLine) Complete() ([]string, error) {
 }
 
 // Consume applies the state of a nested processor
-func (c *CmdLine) Consume(lines []string) {
+func (c *CmdLine) Consume(lines []string) error {
 	for _, line := range lines {
-		c.ProcessLine(line)
+		if err := c.ProcessLine(line); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 // regexpStr converts a single line to regexp format, and insert anti-cmdline

--- a/regex/processors/cmdline_test.go
+++ b/regex/processors/cmdline_test.go
@@ -49,14 +49,16 @@ func (s *cmdLineTestSuite) TestCmdLine_CmdLineTypeFromString() {
 	s.NoError(err)
 	cmd := NewCmdLine(s.ctx, t)
 
-	cmd.ProcessLine(`foo`)
+	err = cmd.ProcessLine(`foo`)
+	s.NoError(err)
 	s.Equal(`f[\x5c'\"\[]*(?:\$[a-z0-9_@?!#{*-]*)?(?:\x5c)?o[\x5c'\"\[]*(?:\$[a-z0-9_@?!#{*-]*)?(?:\x5c)?o`, cmd.proc.lines[0])
 
 	t, err = CmdLineTypeFromString("windows")
 	s.NoError(err)
 	cmd = NewCmdLine(s.ctx, t)
 
-	cmd.ProcessLine(`foo`)
+	err = cmd.ProcessLine(`foo`)
+	s.NoError(err)
 	s.Equal(`f[\"\^]*o[\"\^]*o`, cmd.proc.lines[0])
 }
 
@@ -69,15 +71,17 @@ func (s *cmdLineTestSuite) TestCmdLine_BadCmdLineTypeFromString() {
 func (s *cmdLineTestSuite) TestCmdLine_ProcessLineFoo() {
 	cmd := NewCmdLine(s.ctx, CmdLineUnix)
 
-	cmd.ProcessLine(`foo`)
+	err := cmd.ProcessLine(`foo`)
 
+	s.NoError(err)
 	s.Equal(`f[\x5c'\"\[]*(?:\$[a-z0-9_@?!#{*-]*)?(?:\x5c)?o[\x5c'\"\[]*(?:\$[a-z0-9_@?!#{*-]*)?(?:\x5c)?o`, cmd.proc.lines[0])
 }
 
 func (s *cmdLineTestSuite) TestCmdLine_ProcessLinePattern() {
 	cmd := NewCmdLine(s.ctx, CmdLineUnix)
 
-	cmd.ProcessLine(`gcc-10.`)
+	err := cmd.ProcessLine(`gcc-10.`)
+	s.NoError(err)
 
 	s.Equal(`g[\x5c'\"\[]*(?:\$[a-z0-9_@?!#{*-]*)?(?:\x5c)?c[\x5c'\"\[]*(?:\$[a-z0-9_@?!#{*-]*)?(?:\x5c)?c[\x5c'\"\[]*(?:\$[a-z0-9_@?!#{*-]*)?(?:\x5c)?\-[\x5c'\"\[]*(?:\$[a-z0-9_@?!#{*-]*)?(?:\x5c)?1[\x5c'\"\[]*(?:\$[a-z0-9_@?!#{*-]*)?(?:\x5c)?0[\x5c'\"\[]*(?:\$[a-z0-9_@?!#{*-]*)?(?:\x5c)?\.`, cmd.proc.lines[0])
 }
@@ -85,7 +89,8 @@ func (s *cmdLineTestSuite) TestCmdLine_ProcessLinePattern() {
 func (s *cmdLineTestSuite) TestCmdLine_ProcessLineFooWindows() {
 	cmd := NewCmdLine(s.ctx, CmdLineWindows)
 
-	cmd.ProcessLine(`foo`)
+	err := cmd.ProcessLine(`foo`)
+	s.NoError(err)
 
 	s.Equal(`f[\"\^]*o[\"\^]*o`, cmd.proc.lines[0])
 }

--- a/regex/processors/context.go
+++ b/regex/processors/context.go
@@ -15,6 +15,7 @@ type Context struct {
 	rootContext       *context.Context
 	singleRuleID      int
 	singleChainOffset bool
+	stash             map[string]string
 }
 
 // NewContext creates a new processor context using the `rootDir` as the root directory.
@@ -29,6 +30,7 @@ func NewContext(rootDir string) *Context {
 		rootContext:       context.New(rootDir),
 		singleRuleID:      0,
 		singleChainOffset: false,
+		stash:             map[string]string{},
 	}
 }
 

--- a/regex/processors/processors.go
+++ b/regex/processors/processors.go
@@ -16,11 +16,11 @@ type Processor struct {
 
 type IProcessor interface {
 	// ProcessLine applies the processors logic to a single line
-	ProcessLine(line string)
+	ProcessLine(line string) error
 	// Complete finalizes the processor, producing its output
 	Complete() ([]string, error)
 	// Consume applies the state of a nested processor
-	Consume([]string)
+	Consume([]string) error
 }
 
 // NewProcessor creates a new processor with passed context.

--- a/regex/processors/processors.go
+++ b/regex/processors/processors.go
@@ -15,16 +15,18 @@ type Processor struct {
 }
 
 type IProcessor interface {
+	// ProcessLine applies the processors logic to a single line
 	ProcessLine(line string)
+	// Complete finalizes the processor, producing its output
 	Complete() ([]string, error)
+	// Consume applies the state of a nested processor
 	Consume([]string)
 }
 
 // NewProcessor creates a new processor with passed context.
 func NewProcessor(ctx *Context) *Processor {
-	p := &Processor{
+	return &Processor{
 		ctx:   ctx,
 		lines: []string{},
 	}
-	return p
 }


### PR DESCRIPTION
The main goal of this PR was to clean up the regular expressions generated by the Go regexp library and replace things like `(?-s:.)` with `.`.

While doing this, I discovered that the test suite I was adding tests to for these cases wasn't being run and enabling it showed many of them were failing. I've fixed all of the tests and the associated code, where necessary.