### PR TITLE
Fix formatter (and various issues)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,39 @@
+# https://golangci-lint.run/usage/configuration
+
+linters-settings:
+  gci:
+    # Section configuration to compare against.
+    # Section names are case-insensitive and may contain parameters in ().
+    # The default order of sections is `standard > default > custom > blank > dot`,
+    # If `custom-order` is `true`, it follows the order of `sections` option.
+    # Default: ["standard", "default"]
+    sections:
+      - standard                       # Standard section: captures all standard packages.
+      - default                        # Default section: contains all imports that could not be matched to another section type.
+      - blank                          # Blank section: contains all blank imports. This section is not present unless explicitly enabled.
+      - prefix(github.com/theseion/crs-toolchain) # Custom section: groups all imports with the specified Prefix.
+      # - dot                            # Dot section: contains all dot imports. This section is not present unless explicitly enabled.
+    # Enable custom order of sections.
+    # If `true`, make the section order the same as the order of `sections`.
+    # Default: false
+    custom-order: true
+
+linters:
+  # Disable all linters.
+  # Default: false
+  disable-all: true
+  # Enable specific linter
+  # https://golangci-lint.run/usage/linters/#enabled-by-default
+  enable:
+    - errcheck
+    - gci
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - typecheck
+    - unused
+
+  # Run only fast linters from enabled linters set (first run won't be fast)
+  # Default: false
+  fast: false

--- a/cmd/regex.go
+++ b/cmd/regex.go
@@ -14,7 +14,7 @@ import (
 
 // generateCmd represents the generate command
 var regexCmd = createRegexCommand()
-var ruleIdRegex *regexp.Regexp
+var ruleIdRegex = regexp.MustCompile(`^(\d{6})(?:-chain(\d+))?(?:\.data)?$`)
 var ruleValues struct {
 	id          string
 	fileName    string
@@ -23,7 +23,6 @@ var ruleValues struct {
 }
 
 func init() {
-	ruleIdRegex = regexp.MustCompile(`^(\d{6})(?:-chain(\d+))?(?:\.data)?$`)
 	buildRegexCommand()
 }
 

--- a/cmd/regex_compare.go
+++ b/cmd/regex_compare.go
@@ -116,7 +116,7 @@ func performCompare(processAll bool, ctx *processors.Context) {
 					return errors.New("failed to match chain offset. Value must not be larger than 255")
 				}
 				regex := runAssemble(filePath, ctx)
-				processRegex(id, uint8(chainOffset), regex, ctx)
+				processRule(id, uint8(chainOffset), regex, ctx)
 				return nil
 			}
 			return nil

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,11 +11,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const defaultLogLevel = zerolog.ErrorLevel
+const defaultLogLevel = zerolog.InfoLevel
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = createRootCommand()
-var logger zerolog.Logger
+var logger = log.With().Str("component", "cmd").Logger()
 var rootValues = struct {
 	output           outputType
 	logLevel         logLevel
@@ -30,10 +30,6 @@ func Execute() {
 }
 
 func init() {
-	zerolog.SetGlobalLevel(defaultLogLevel)
-	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: "03:04:05"})
-	logger = log.With().Str("component", "cmd").Caller().Logger()
-
 	cwd, err := os.Getwd()
 	if err != nil {
 		logger.Fatal().Err(err).Msg("Failed to resolve working directory")
@@ -44,7 +40,7 @@ func init() {
 		workingDirectory workingDirectory
 	}{
 		output:           text,
-		logLevel:         logLevel(zerolog.LevelErrorValue),
+		logLevel:         logLevel(defaultLogLevel.String()),
 		workingDirectory: workingDirectory(cwd),
 	}
 
@@ -60,7 +56,7 @@ func createRootCommand() *cobra.Command {
 
 func buildRootCommand() {
 	rootCmd.PersistentFlags().VarP(&rootValues.logLevel, "log-level", "l",
-		`Set the application log level. Default: 'error'.
+		`Set the application log level. Default: 'info'.
 Options: 'trace', 'debug', 'info', 'warn', 'error', 'fatal', 'panic', 'disabled`)
 	rootCmd.PersistentFlags().VarP(&rootValues.output, "output", "o", "Output format. One of 'text', 'github'. Default: 'text'")
 	rootCmd.PersistentFlags().VarP(&rootValues.workingDirectory, "directory", "d",

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/suite"
+
+	loggerConfig "github.com/theseion/crs-toolchain/v2/logger"
 )
 
 type rootTestSuite struct {
@@ -58,7 +60,7 @@ func (s *rootTestSuite) TestRoot_LogLevelDefault() {
 	s.NotNil(logLevelFlag)
 	s.False(logLevelFlag.Changed)
 
-	s.Equal(zerolog.ErrorLevel, zerolog.GlobalLevel())
+	s.Equal(loggerConfig.DefaultLogLevel, zerolog.GlobalLevel())
 }
 
 func (s *rootTestSuite) TestRoot_LogLevelChanged() {
@@ -82,7 +84,7 @@ func (s *rootTestSuite) TestRoot_LogLevelInvalidShouldBeDefault() {
 	s.NotNil(logLevelFlag)
 	s.True(logLevelFlag.Changed)
 
-	s.Equal(zerolog.GlobalLevel(), zerolog.ErrorLevel)
+	s.Equal(zerolog.GlobalLevel(), loggerConfig.DefaultLogLevel)
 }
 
 func (s *rootTestSuite) TestRoot_LogLevelAllowedAnywhere() {

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,0 +1,18 @@
+// Copyright 2022 OWASP Core Rule Set Project
+// SPDX-License-Identifier: Apache-2.0
+
+package logger
+
+import (
+	"os"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+)
+
+const DefaultLogLevel zerolog.Level = zerolog.InfoLevel
+
+func init() {
+	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: "03:04:05"}).With().Caller().Logger()
+	zerolog.SetGlobalLevel(DefaultLogLevel)
+}

--- a/magefile.go
+++ b/magefile.go
@@ -20,6 +20,7 @@ import (
 var addLicenseVersion = "v1.0.0" // https://github.com/google/addlicense
 var golangCILintVer = "v1.48.0"  // https://github.com/golangci/golangci-lint/releases
 var gosImportsVer = "v0.1.5"     // https://github.com/rinchsan/gosimports/releases/tag/v0.1.5
+var goGciVer = "v0.8.2"          // https://github.com/daixiang0/gci/releases/tag/v0.8.2
 
 var errCommitFormatting = errors.New("files not formatted, please commit formatting changes")
 var errNoGitDir = errors.New("no .git directory found")
@@ -39,10 +40,26 @@ func Format() error {
 		"-ignore", "examples/**", "."); err != nil {
 		return err
 	}
-	return sh.RunV("go", "run", fmt.Sprintf("github.com/rinchsan/gosimports/cmd/gosimports@%s", gosImportsVer),
+	if err := sh.RunV("go", "run", fmt.Sprintf("github.com/rinchsan/gosimports/cmd/gosimports@%s", gosImportsVer),
 		"-w",
 		"-local",
 		"github.com/theseion/crs-toolchain",
+		"."); err != nil {
+		return err
+	}
+
+	return sh.RunV("go", "run", fmt.Sprintf("github.com/daixiang0/gci@%s", goGciVer),
+		"write",
+		"--section",
+		"standard",
+		"--section",
+		"default",
+		"--section",
+		"blank",
+		"--section",
+		"prefix(github.com/theseion/crs-toolchain)",
+		"--custom-order",
+		"--skip-generated",
 		".")
 }
 

--- a/main.go
+++ b/main.go
@@ -4,6 +4,8 @@
 package main
 
 import (
+	_ "github.com/theseion/crs-toolchain/v2/logger"
+
 	"github.com/theseion/crs-toolchain/v2/cmd"
 )
 

--- a/regex/operators/assembler.go
+++ b/regex/operators/assembler.go
@@ -20,6 +20,11 @@ import (
 
 var preprocessorStart = regexp.MustCompile(`^##!>\s*([a-z]+)(?:\s+([a-z]+))?`)
 var preprocessorEnd = regexp.MustCompile(`^##!<`)
+var metaGroupReplacements = map[string]string{
+	"(?-s:.)": ".",
+	"(?m:^)":  "^",
+	"(?m:$)":  "$",
+}
 
 // Create the processor stack
 var processorStack ProcessorStack
@@ -202,7 +207,6 @@ func (a *Operator) escapeDoublequotes(input string) string {
 // readbility reasons, as Apache httpd handles sequences of backslashes
 // differently than nginx.
 func (a *Operator) useHexBackslashes(input string) string {
-	logger.Trace().Msg("Replacing literal backslashes with \\x5c")
 	return strings.ReplaceAll(input, `\\`, `\x5c`)
 }
 
@@ -215,6 +219,7 @@ func (a *Operator) useHexBackslashes(input string) string {
 // compatible engines.
 func (a *Operator) includeVerticalTabInSpaceClass(input string) string {
 	logger.Trace().Msg("Fixing up regex to include \\v in white space class matches")
+	// Note: replacement order is important. Don't use a map.
 	result := strings.ReplaceAll(input, `[\t-\n\f-\r ]`, `[\s\v]`)
 	result = strings.ReplaceAll(result, `[^\t-\n\f-\r ]`, `[^\s\v]`)
 	// There's a range attached, can't just replace
@@ -253,13 +258,17 @@ func (a *Operator) useHexEscapes(input string) string {
 	return sb.String()
 }
 
-// The Go regexp/syntax library will convert a dot (`.`) into `(?-s:.)`,
-// `^` to `(?m:^)`, `$` to (?m:$)`.
+// The Go regexp/syntax library will convert:
+// - a dot (`.`) into `(?-s:.)`
+// - a caret (`^`) into `(?m:^)`
+// - a dollar (`$`) into (?m:$)`
 // We want to retain the original dot.
 func (a *Operator) dontUseFlagsForMetaCharacters(input string) string {
-	result := strings.ReplaceAll(input, "(?-s:.)", ".")
-	result = strings.ReplaceAll(result, "(?m:^)", "^")
-	return strings.ReplaceAll(result, "(?m:$)", "$")
+	result := input
+	for needle, replacement := range metaGroupReplacements {
+		result = strings.ReplaceAll(result, needle, replacement)
+	}
+	return result
 }
 
 func (a *Operator) startPreprocessor(processorName string, args []string) error {

--- a/regex/operators/assembler.go
+++ b/regex/operators/assembler.go
@@ -40,7 +40,7 @@ func (a *Operator) Run(input string) (string, error) {
 	processorStack = NewProcessorStack()
 	logger.Trace().Msg("Starting assembler")
 	assembleParser := parser.NewParser(a.ctx, strings.NewReader(input))
-	lines, _ := assembleParser.Parse()
+	lines, _ := assembleParser.Parse(false)
 	logger.Trace().Msgf("Parsed lines: %v", lines)
 	assembled, err := a.assemble(assembleParser, lines)
 	if err != nil {

--- a/regex/processors/cmdline.go
+++ b/regex/processors/cmdline.go
@@ -99,7 +99,7 @@ func NewCmdLine(ctx *Context, cmdType CmdLineType) *CmdLine {
 	return a
 }
 
-// ProcessLine implements the line processor
+// ProcessLine applies the processors logic to a single line
 func (c *CmdLine) ProcessLine(line string) error {
 	if len(line) != 0 {
 		processed := c.regexpStr(line)
@@ -118,6 +118,16 @@ func (c *CmdLine) Complete() ([]string, error) {
 	}
 	logger.Trace().Msgf("cmdLine Complete result: %v", assembly)
 	return []string{assembly}, nil
+}
+
+// Consume applies the state of a nested processor
+func (c *CmdLine) Consume(lines []string) error {
+	for _, line := range lines {
+		if err := c.ProcessLine(line); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // regexpStr converts a single line to regexp format, and insert anti-cmdline

--- a/regex/processors/cmdline.go
+++ b/regex/processors/cmdline.go
@@ -99,7 +99,7 @@ func NewCmdLine(ctx *Context, cmdType CmdLineType) *CmdLine {
 	return a
 }
 
-// ProcessLine applies the processors logic to a single line
+// ProcessLine implements the line processor
 func (c *CmdLine) ProcessLine(line string) error {
 	if len(line) != 0 {
 		processed := c.regexpStr(line)
@@ -110,7 +110,7 @@ func (c *CmdLine) ProcessLine(line string) error {
 	return nil
 }
 
-// Complete finalizes the processor, producing its output
+// Complete is the class method
 func (c *CmdLine) Complete() ([]string, error) {
 	assembly, err := rassemble.Join(c.proc.lines)
 	if err != nil {
@@ -118,16 +118,6 @@ func (c *CmdLine) Complete() ([]string, error) {
 	}
 	logger.Trace().Msgf("cmdLine Complete result: %v", assembly)
 	return []string{assembly}, nil
-}
-
-// Consume applies the state of a nested processor
-func (c *CmdLine) Consume(lines []string) error {
-	for _, line := range lines {
-		if err := c.ProcessLine(line); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 // regexpStr converts a single line to regexp format, and insert anti-cmdline


### PR DESCRIPTION
I wanted to fix one thing in the formatter and added up with this huge PR. Unfortunately, most of the things tie into each other.

- format all directives consistently
- also indent comments
- don't indent processors without body
- fix broken tests (all packages)
- let parser know that it must retain lines for formatting
- don't run include or definition processors when formatting
- fix order of logger instantiation