### PR TITLE
fix(parser): handle flags, prefixes, and suffixes in include files

### DIFF
--- a/regex/definitions.go
+++ b/regex/definitions.go
@@ -14,7 +14,7 @@ var IncludeRegex = regexp.MustCompile(`^##!>\s*include\s*(.*)$`)
 var DefinitionRegex = regexp.MustCompile(`^##!>\s*define\s+([a-zA-Z0-9-_]+)\s+(.*)$`)
 
 // CommentRegex matches a comment line (##!, no other directives)
-var CommentRegex = regexp.MustCompile(`^##![^^$+><=]`)
+var CommentRegex = regexp.MustCompile(`^##!(?:[^^$+><=]|$)`)
 
 // FlagsRegex matches a flags line (##!+ <value>).
 // The value is captured in group 1.

--- a/regex/operators/assembler_test.go
+++ b/regex/operators/assembler_test.go
@@ -95,6 +95,7 @@ func (s *definitionsTestSuite) TearDownSuite() {
 
 func (s *fileFormatTestSuite) TestPreprocessIgnoresSimpleComments() {
 	contents := `##!line1
+##!
 ##! line2
 ##!\tline3
 `

--- a/regex/parser/parser.go
+++ b/regex/parser/parser.go
@@ -14,6 +14,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/imdario/mergo"
@@ -118,7 +119,7 @@ func (p *Parser) Parse(formatOnly bool) (*bytes.Buffer, int) {
 		case include:
 			if !formatOnly {
 				// go read the included file and paste text here
-				content, _ := includeFile(p.ctx, parsedLine.result[includePatternName])
+				content, _ := includeFile(p, parsedLine.result[includePatternName])
 				text = content.String()
 			}
 		case flags:
@@ -197,7 +198,7 @@ func (p *Parser) parseLine(line string) ParsedLine {
 }
 
 // includeFile does just a new call to the Parser on the named file. It will use the context to find files that have relative filenames.
-func includeFile(ctx *processors.Context, includeName string) (*bytes.Buffer, int) {
+func includeFile(rootParser *Parser, includeName string) (*bytes.Buffer, int) {
 	filename := includeName
 	logger.Trace().Msgf("reading include file: %v", filename)
 	if path.Ext(filename) != ".data" {
@@ -207,14 +208,49 @@ func includeFile(ctx *processors.Context, includeName string) (*bytes.Buffer, in
 	// check if filename has an absolute path
 	// if it is relative, use the context to get the parent directory where we should search for the file.
 	if !filepath.IsAbs(filename) {
-		filename = filepath.Join(ctx.RootContext().IncludeDir(), filename)
+		filename = filepath.Join(rootParser.ctx.RootContext().IncludeDir(), filename)
 	}
 	readFile, err := os.Open(filename)
 	if err != nil {
 		logger.Fatal().Msgf("cannot open file for inclusion: %v", err.Error())
 	}
-	newP := NewParser(ctx, bufio.NewReader(readFile))
-	return newP.Parse(false)
+	newP := NewParser(rootParser.ctx, bufio.NewReader(readFile))
+	out, _ := newP.Parse(false)
+	newOut := mergeFlagsPrefixesSuffixes(rootParser, newP, out)
+	logger.Trace().Msg(newOut.String())
+	return newOut, newOut.Len()
+}
+
+// Merge flags, prefixes, and suffixes from include files into another parser.
+// All of these need to be treated as local to the source parser.
+func mergeFlagsPrefixesSuffixes(target *Parser, source *Parser, out *bytes.Buffer) *bytes.Buffer {
+	logger.Trace().Msg("merging flags, prefixes, suffixes from included file")
+	newOut := new(bytes.Buffer)
+	newOut.WriteString("##!> assemble\n")
+
+	if len(source.Flags) > 0 {
+		flags := make([]string, 0, len(source.Flags))
+		for flag := range source.Flags {
+			flags = append(flags, string(flag))
+		}
+		sort.Strings(flags)
+		newOut.WriteString("(?" + strings.Join(flags, "") + ")")
+		newOut.WriteString("\n##!=>\n")
+	}
+	for _, prefix := range source.Prefixes {
+		newOut.WriteString(prefix)
+		newOut.WriteString("\n##!=>\n")
+	}
+	if _, err := out.WriteTo(newOut); err != nil {
+		logger.Fatal().Err(err).Msg("failed to copy output to new buffer")
+	}
+	for _, suffix := range source.Suffixes {
+		newOut.WriteString("\n##!=>\n")
+		newOut.WriteString(suffix)
+		newOut.WriteString("\n##!=>\n")
+	}
+	newOut.WriteString("##!<\n")
+	return newOut
 }
 
 func expandDefinitions(src *bytes.Buffer, variables map[string]string) *bytes.Buffer {

--- a/regex/parser/parser.go
+++ b/regex/parser/parser.go
@@ -225,6 +225,13 @@ func includeFile(rootParser *Parser, includeName string) (*bytes.Buffer, int) {
 // All of these need to be treated as local to the source parser.
 func mergeFlagsPrefixesSuffixes(target *Parser, source *Parser, out *bytes.Buffer) *bytes.Buffer {
 	logger.Trace().Msg("merging flags, prefixes, suffixes from included file")
+	// IMPORTANT: don't write the assemble block at all if there are no flags, prefixes, or
+	// suffixes. Enclosing the output in an assemble block can change the semantics, for example,
+	// when the included content is processed by the cmdline processor in the including file.
+	if len(source.Flags) == 0 && len(source.Prefixes) == 0 && len(source.Suffixes) == 0 {
+		return out
+	}
+
 	newOut := new(bytes.Buffer)
 	newOut.WriteString("##!> assemble\n")
 

--- a/regex/parser/parser_test.go
+++ b/regex/parser/parser_test.go
@@ -120,7 +120,7 @@ func (s *parserIncludeTestSuite) TestParserInclude_FromFile() {
 	s.writeDataFile("This data comes from the include file.\n", "##!This is a comment\n")
 	parser := NewParser(s.ctx, s.reader)
 	actual, n := parser.Parse(false)
-	expected := bytes.NewBufferString("##!> assemble\nThis data comes from the include file.\n##!<\n")
+	expected := bytes.NewBufferString("This data comes from the include file.\n")
 
 	s.Equal(expected.String(), actual.String())
 	s.Equal(expected.Len(), n)
@@ -260,17 +260,9 @@ func (s *parserMultiIncludeTestSuite) TestParserMultiInclude_FromMultiFile() {
 	parser := NewParser(s.ctx, s.reader)
 	actual, n := parser.Parse(false)
 	expected := bytes.NewBufferString(
-		"##!> assemble\n" +
-			"##!> assemble\n" +
-			"##!> assemble\n" +
-			"##!> assemble\n" +
-			"##!<\n" +
-			"This is comment 3.\n" +
-			"##!<\n" +
+		"This is comment 3.\n" +
 			"This is comment 2.\n" +
-			"##!<\n" +
 			"This is comment 1.\n" +
-			"##!<\n" +
 			"This is comment 0.\n")
 
 	s.Equal(expected.String(), actual.String())
@@ -352,20 +344,12 @@ func (s *parserIncludeWithDefinitions) TestParser_IncludeWithDefinitions() {
 	parser := NewParser(s.ctx, s.reader)
 	actual, _ := parser.Parse(false)
 	expected := bytes.NewBufferString(
-		"##!> assemble\n" +
-			"##!> assemble\n" +
-			"##!> assemble\n" +
-			"##!> assemble\n" +
-			"##!<\n" +
-			"This is comment 3.\n" +
+		"This is comment 3.\n" +
 			"[a-zA-J]+8 to see if definitions work when included\n" +
-			"##!<\n" +
 			"This is comment 2.\n" +
 			"[a-zA-J]+8 to see if definitions work when included\n" +
-			"##!<\n" +
 			"This is comment 1.\n" +
 			"[a-zA-J]+8 to see if definitions work when included\n" +
-			"##!<\n" +
 			"[a-zA-J]+8 to see if definitions work.\n" +
 			"Second text for [0-9](pine|apple).\n")
 


### PR DESCRIPTION
In the toolchain, the parser holds the flags, prefixes and suffixes and the assembler uses them when finalizing the assembly. The parsers of include files, however, aren't known to the assembler. In addition, the flags, prefixes, and suffixes in include files must be scoped to the include file.

This commit adds a new function to post process include file parsing. The included content is enclosed in a new assemble block and flags, prefixes, and suffixes are perpended / appended to the content.

Fixes #40.