### PR TITLE
fix(dir): update data directory after movement

### DIFF
--- a/cmd/flag_types.go
+++ b/cmd/flag_types.go
@@ -101,7 +101,7 @@ func (w *workingDirectory) Type() string {
 
 func findRootDirectory(startPath string) (string, error) {
 	logger.Trace().Msgf("Searching for root directory starting at %s", startPath)
-	dataPath := path.Join("util", "regexp-assemble", "data")
+	dataPath := path.Join("data")
 	currentPath := startPath
 	// root directory only will have a separator as the last rune
 	for currentPath[len(currentPath)-1] != filepath.Separator {

--- a/cmd/regex_compare_test.go
+++ b/cmd/regex_compare_test.go
@@ -38,7 +38,7 @@ func (s *compareTestSuite) SetupTest() {
 	s.NoError(err)
 	s.tempDir = tempDir
 
-	s.dataDir = path.Join(s.tempDir, "util", "regexp-assemble", "data")
+	s.dataDir = path.Join(s.tempDir, "data")
 	err = os.MkdirAll(s.dataDir, fs.ModePerm)
 	s.NoError(err)
 

--- a/cmd/regex_format_test.go
+++ b/cmd/regex_format_test.go
@@ -26,7 +26,7 @@ func (s *formatTestSuite) SetupTest() {
 	s.NoError(err)
 	s.tempDir = tempDir
 
-	s.dataDir = path.Join(s.tempDir, "util", "regexp-assemble", "data")
+	s.dataDir = path.Join(s.tempDir, "data")
 	err = os.MkdirAll(s.dataDir, fs.ModePerm)
 	s.NoError(err)
 

--- a/cmd/regex_generate_test.go
+++ b/cmd/regex_generate_test.go
@@ -25,7 +25,7 @@ func (s *generateTestSuite) SetupTest() {
 	s.NoError(err)
 	s.tempDir = tempDir
 
-	s.dataDir = path.Join(s.tempDir, "util", "regexp-assemble", "data")
+	s.dataDir = path.Join(s.tempDir, "data")
 	err = os.MkdirAll(s.dataDir, fs.ModePerm)
 	s.NoError(err)
 }

--- a/cmd/regex_test.go
+++ b/cmd/regex_test.go
@@ -27,7 +27,7 @@ func (s *regexTestSuite) SetupTest() {
 	s.NoError(err)
 	s.tempDir = tempDir
 
-	s.dataDir = path.Join(s.tempDir, "util", "regexp-assemble", "data")
+	s.dataDir = path.Join(s.tempDir, "data")
 	err = os.MkdirAll(s.dataDir, fs.ModePerm)
 	s.NoError(err)
 

--- a/cmd/regex_update_test.go
+++ b/cmd/regex_update_test.go
@@ -27,7 +27,7 @@ func (s *updateTestSuite) SetupTest() {
 	s.NoError(err)
 	s.tempDir = tempDir
 
-	s.dataDir = path.Join(s.tempDir, "util", "regexp-assemble", "data")
+	s.dataDir = path.Join(s.tempDir, "data")
 	err = os.MkdirAll(s.dataDir, fs.ModePerm)
 	s.NoError(err)
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -30,7 +30,7 @@ func (suite *rootTestSuite) SetupTest() {
 	suite.NoError(err)
 	suite.tempDir = tempDir
 
-	suite.dataDir = path.Join(suite.tempDir, "util", "regexp-assemble", "data")
+	suite.dataDir = path.Join(s.tempDir, "data")
 	err = os.MkdirAll(suite.dataDir, fs.ModePerm)
 	suite.NoError(err)
 }
@@ -116,7 +116,7 @@ func (s *rootTestSuite) TestRoot_RelativeWorkingDirectory() {
 	cwd, err := os.Getwd()
 	s.NoError(err)
 	parentCwd := path.Dir(cwd)
-	err = os.MkdirAll(path.Join(parentCwd, "testDir", "util", "regexp-assemble", "data"), fs.ModePerm)
+	err = os.MkdirAll(path.Join(parentCwd, "testDir", "data"), fs.ModePerm)
 	s.NoError(err)
 	defer os.RemoveAll(path.Join(parentCwd, "testDir"))
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -30,14 +30,14 @@ func (s *rootTestSuite) SetupTest() {
 	s.NoError(err)
 	s.tempDir = tempDir
 
-	s = path.Join(s.tempDir, "data")
-	err = os.MkdirAll(suite.dataDir, fs.ModePerm)
-	suite.NoError(err)
+	s.dataDir = path.Join(s.tempDir, "data")
+	err = os.MkdirAll(s.dataDir, fs.ModePerm)
+	s.NoError(err)
 }
 
 func (s *rootTestSuite) TearDownTest() {
 	err := os.RemoveAll(s.tempDir)
-	suite.NoError(err)
+	s.NoError(err)
 }
 
 func TestRunRootTestSuite(t *testing.T) {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -21,22 +21,22 @@ type rootTestSuite struct {
 	dataDir string
 }
 
-func (suite *rootTestSuite) SetupTest() {
+func (s *rootTestSuite) SetupTest() {
 	rebuildRootCommand()
 	rebuildRegexCommand()
 	zerolog.SetGlobalLevel(defaultLogLevel)
 
 	tempDir, err := os.MkdirTemp("", "root-tests")
-	suite.NoError(err)
-	suite.tempDir = tempDir
+	s.NoError(err)
+	s.tempDir = tempDir
 
-	suite.dataDir = path.Join(s.tempDir, "data")
+	s = path.Join(s.tempDir, "data")
 	err = os.MkdirAll(suite.dataDir, fs.ModePerm)
 	suite.NoError(err)
 }
 
-func (suite *rootTestSuite) TearDownTest() {
-	err := os.RemoveAll(suite.tempDir)
+func (s *rootTestSuite) TearDownTest() {
+	err := os.RemoveAll(s.tempDir)
 	suite.NoError(err)
 }
 

--- a/cmd/util_renumber_tests_test.go
+++ b/cmd/util_renumber_tests_test.go
@@ -26,7 +26,7 @@ func (s *renumberTestsTestSuite) SetupTest() {
 	s.NoError(err)
 	s.tempDir = tempDir
 
-	dataDir := path.Join(s.tempDir, "util", "regexp-assemble", "data")
+	dataDir := path.Join(s.tempDir, "data")
 	err = os.MkdirAll(dataDir, fs.ModePerm)
 	s.NoError(err)
 

--- a/context/context.go
+++ b/context/context.go
@@ -6,7 +6,6 @@ package context
 type Context struct {
 	rootDirectory                string
 	rulesDirectory               string
-	utilDirectory                string
 	dataFilesDirectory           string
 	includeFilesDirectory        string
 	regressionTestFilesDirectory string
@@ -16,7 +15,6 @@ func New(rootDir string) *Context {
 	return &Context{
 		rootDirectory:                rootDir,
 		rulesDirectory:               rootDir + "/rules",
-		utilDirectory:                rootDir + "/util",
 		dataFilesDirectory:           rootDir + "/data",
 		includeFilesDirectory:        rootDir + "/data/include",
 		regressionTestFilesDirectory: rootDir + "/tests/regression/tests",
@@ -41,11 +39,6 @@ func (ctx *Context) IncludeDir() string {
 // RulesDir returns the 'rules' directory.
 func (ctx *Context) RulesDir() string {
 	return ctx.rulesDirectory
-}
-
-// UtilDir returns the 'util' directory.
-func (ctx *Context) UtilDir() string {
-	return ctx.utilDirectory
 }
 
 // RegressionTestsDir returns the 'tests' directory of regression tests.

--- a/context/context.go
+++ b/context/context.go
@@ -17,8 +17,8 @@ func New(rootDir string) *Context {
 		rootDirectory:                rootDir,
 		rulesDirectory:               rootDir + "/rules",
 		utilDirectory:                rootDir + "/util",
-		dataFilesDirectory:           rootDir + "/util/regexp-assemble/data",
-		includeFilesDirectory:        rootDir + "/util/regexp-assemble/data/include",
+		dataFilesDirectory:           rootDir + "/data",
+		includeFilesDirectory:        rootDir + "/data/include",
 		regressionTestFilesDirectory: rootDir + "/tests/regression/tests",
 	}
 }

--- a/regex/parser/parser_test.go
+++ b/regex/parser/parser_test.go
@@ -101,7 +101,7 @@ func (s *parserIncludeTestSuite) SetupSuite() {
 	s.tempDir, err = os.MkdirTemp("", "include-tests")
 	s.NoError(err)
 
-	s.includeDir = path.Join(s.tempDir, "util", "regexp-assemble", "data", "include")
+	s.includeDir = path.Join(s.tempDir, "data", "include")
 	err = os.MkdirAll(s.includeDir, fs.ModePerm)
 	s.NoError(err)
 
@@ -145,7 +145,7 @@ func (s *parserMultiIncludeTestSuite) SetupSuite() {
 	s.NoError(err)
 	s.tempDir = tempDir
 
-	s.includeDir = path.Join(s.tempDir, "util", "regexp-assemble", "data", "include")
+	s.includeDir = path.Join(s.tempDir, "data", "include")
 	err = os.MkdirAll(s.includeDir, fs.ModePerm)
 	s.NoError(err)
 
@@ -221,7 +221,7 @@ func (s *parserIncludeWithDefinitions) SetupSuite() {
 	s.NoError(err)
 	s.tempDir = tempDir
 
-	s.includeDir = path.Join(s.tempDir, "util", "regexp-assemble", "data", "include")
+	s.includeDir = path.Join(s.tempDir, "data", "include")
 	err = os.MkdirAll(s.includeDir, fs.ModePerm)
 	s.NoError(err)
 

--- a/regex/processors/assemble_test.go
+++ b/regex/processors/assemble_test.go
@@ -52,7 +52,7 @@ func (s *assembleTestSuite) TestNewAssemble() {
 
 	s.NotNil(assemble)
 	s.Equal(assemble.proc.ctx.RootContext().RootDir(), s.tempDir)
-	s.Equal(assemble.proc.ctx.RootContext().DataDir(), s.tempDir+"/util/regexp-assemble/data")
+	s.Equal(assemble.proc.ctx.RootContext().DataDir(), s.tempDir+"/data")
 }
 
 func (s *assembleTestSuite) TestAssemble_MultipleLines() {


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

After merging https://github.com/coreruleset/coreruleset/pull/3002 we need to update all data paths here also.