### PR TITLE
feat: add check for unknown definitions

### DIFF
--- a/regex/definitions.go
+++ b/regex/definitions.go
@@ -63,3 +63,7 @@ var RuleIdFileNameRegex = regexp.MustCompile(`^(\d{6})(?:-chain(\d+))?(?:\.data)
 // TestTitleRegex matches any test_title line in test YAML files (test_title: "<title>").
 // Everything up to the value of the test title is captured in group 1.
 var TestTitleRegex = regexp.MustCompile(`(.*test_title:\s*)"?[^"]+"?\s*$`)
+
+// DefinitionReferenceRegex matches any reference to a definition.
+// The matched reference name will be captured in group 1.
+var DefinitionReferenceRegex = regexp.MustCompile(`{{([a-zA-Z0-9-_]+)}}`)

--- a/regex/parser/parser.go
+++ b/regex/parser/parser.go
@@ -231,6 +231,12 @@ func expandDefinitions(src *bytes.Buffer, variables map[string]string) *bytes.Bu
 		needle := "{{" + needle + "}}"
 		src = bytes.NewBuffer(bytes.ReplaceAll(src.Bytes(), []byte(needle), []byte(replacement)))
 	}
+	// After all replacements, check if we have dangling names around. They mean that no definition was created
+	// yet, or there is a typo.
+	dangling := regex.DefinitionReferenceRegex.FindSubmatch(src.Bytes())
+	if dangling != nil {
+		logger.Warn().Msgf("no match found for definition: {{%s}}. could be a typo, or you forgot to define it?", string(dangling[1]))
+	}
 	logger.Trace().Msgf("expanded all definitions in: %v", src.String())
 	return src
 }


### PR DESCRIPTION
Warn if after doing definitions substitution there are still references to names without resolution.
They might happen because something was moved or renamed, or there is a typo somewhere.

Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

Fixes #39.